### PR TITLE
Don't use p2p for cardano-node

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,6 @@ Metrics/ModuleLength:
 
 Lint/OrAssignmentToConstant:
   Enabled: false
+
+Lint/DuplicateBranch:
+  Enabled: false

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## [0.1.5] - 2023-04-04
+
+## Changed
+ - don't use p2p for cardano-node (#8)
+
 ## [0.1.4] - 2023-03-01
 
 ## Added

--- a/lib/cardano-up/version.rb
+++ b/lib/cardano-up/version.rb
@@ -2,5 +2,5 @@
 
 # Version
 module CardanoUp
-  VERSION ||= '0.1.4'
+  VERSION ||= '0.1.5'
 end


### PR DESCRIPTION
For the time being `cardano-wallet` bundle from where `cardano-up` takes binaries has `cardano-node` 1.35.4. This PR is to make sure we're not using p2p with it.